### PR TITLE
build: update to Rust 1.70

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # --- build image
 
-FROM rust:1.69 AS builder
+FROM rust:1.70 AS builder
 
 RUN rustup target add x86_64-unknown-linux-musl
 RUN apt update && apt install -y musl-tools musl-dev


### PR DESCRIPTION
Update the Rust toolchain version in the Dockerfile.

Tested the change on an x86 VM, the build succeeds.

Closes #31 