### PR TITLE
Add nix to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ services:
 ```
 Make sure the `./data` folder is writable by the user 10001.
 
+### Run with Nix
+
+For Nix users, a `flake.nix` is also provided. Build and execute it directly
+with:
+
+```sh
+nix run 'github:matze/wastebin#wastebin' 
+```
+
+Or install the provided `wastebin` package like you normally would.
+
 ## Usage
 
 ### Browser interface


### PR DESCRIPTION
As suggested in #45 I added a comment on nix to the readme. Didn't go into much detail, but should be more than enough for Nixos users to know how to use it. I'm also working on adding it as an official nixos package over on https://github.com/NixOS/nixpkgs/pull/287455