### PR TITLE
Handle serving from a sub-path

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,3 +18,4 @@ jobs:
         components: clippy
     - run: cargo clippy -- -W clippy::pedantic
     - run: cargo test
+    - run: WASTEBIN_BASE_URL="http://127.0.0.1:8080/wastebin" cargo test  # port is not relevant

--- a/src/env.rs
+++ b/src/env.rs
@@ -160,7 +160,7 @@ pub fn base_path() -> &'static BasePath {
                     if path.ends_with('/') {
                         BasePath(path.to_string())
                     } else {
-                        BasePath("${path}/".to_string())
+                        BasePath(format!("{path}/"))
                     }
                 }
                 Err(err) => {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,3 +1,4 @@
+use crate::routes::{base_path, DEFAULT_BASE_PATH};
 use crate::{db, highlight};
 use axum_extra::extract::cookie::Key;
 use std::env::VarError;
@@ -12,6 +13,7 @@ pub struct Metadata<'a> {
     pub title: String,
     pub version: &'a str,
     pub highlight: &'a highlight::Data<'a>,
+    pub base_path: &'a str,
 }
 
 pub const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -56,10 +58,16 @@ pub fn metadata() -> &'static Metadata<'static> {
         let version = env!("CARGO_PKG_VERSION");
         let highlight = &highlight::data();
 
+        let base_path = match base_url() {
+            Err(_) => DEFAULT_BASE_PATH,
+            Ok(base_url) => String::from(base_path(&base_url)).leak(),
+        };
+
         Metadata {
             title,
             version,
             highlight,
+            base_path,
         }
     })
 }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -73,7 +73,7 @@ pub struct Data<'a> {
 impl<'a> Css<'a> {
     fn new(name: &str, content: &'a str) -> Self {
         let name = format!(
-            "/{name}.{}.css",
+            "{name}.{}.css",
             hex::encode(Sha256::digest(content.as_bytes()))
                 .get(0..16)
                 .expect("at least 16 characters")

--- a/src/id.rs
+++ b/src/id.rs
@@ -27,7 +27,7 @@ impl Id {
         entry
             .extension
             .as_ref()
-            .map_or_else(|| format!("/{self}"), |ext| format!("/{self}.{ext}"))
+            .map_or_else(|| format!("{self}"), |ext| format!("{self}.{ext}"))
     }
 }
 

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -11,6 +11,7 @@ use std::default::Default;
 #[template(path = "error.html")]
 pub struct Error<'a> {
     meta: &'a env::Metadata<'a>,
+    base_path: &'static env::BasePath,
     error: String,
 }
 
@@ -21,6 +22,7 @@ impl From<crate::Error> for ErrorResponse<'_> {
     fn from(err: crate::Error) -> Self {
         let html = Error {
             meta: env::metadata(),
+            base_path: env::base_path(),
             error: err.to_string(),
         };
 
@@ -33,12 +35,14 @@ impl From<crate::Error> for ErrorResponse<'_> {
 #[template(path = "index.html")]
 pub struct Index<'a> {
     meta: &'a env::Metadata<'a>,
+    base_path: &'static env::BasePath,
 }
 
 impl<'a> Default for Index<'a> {
     fn default() -> Self {
         Self {
             meta: env::metadata(),
+            base_path: env::base_path(),
         }
     }
 }
@@ -48,6 +52,7 @@ impl<'a> Default for Index<'a> {
 #[template(path = "formatted.html")]
 pub struct Paste<'a> {
     meta: &'a env::Metadata<'a>,
+    base_path: &'static env::BasePath,
     id: String,
     ext: String,
     can_delete: bool,
@@ -61,6 +66,7 @@ impl<'a> Paste<'a> {
 
         Self {
             meta: env::metadata(),
+            base_path: env::base_path(),
             id: key.id(),
             ext: key.ext,
             can_delete,
@@ -74,6 +80,7 @@ impl<'a> Paste<'a> {
 #[template(path = "encrypted.html")]
 pub struct Encrypted<'a> {
     meta: &'a env::Metadata<'a>,
+    base_path: &'static env::BasePath,
     id: String,
     ext: String,
     query: String,
@@ -91,6 +98,7 @@ impl<'a> Encrypted<'a> {
 
         Self {
             meta: env::metadata(),
+            base_path: env::base_path(),
             id: key.id(),
             ext: key.ext,
             query,
@@ -103,6 +111,7 @@ impl<'a> Encrypted<'a> {
 #[template(path = "qr.html", escape = "none")]
 pub struct Qr<'a> {
     meta: &'a env::Metadata<'a>,
+    base_path: &'static env::BasePath,
     id: String,
     ext: String,
     can_delete: bool,
@@ -114,6 +123,7 @@ impl<'a> Qr<'a> {
     pub fn new(code: qrcodegen::QrCode, key: CacheKey) -> Self {
         Self {
             meta: env::metadata(),
+            base_path: env::base_path(),
             id: key.id(),
             ext: key.ext,
             code,
@@ -136,6 +146,7 @@ impl<'a> Qr<'a> {
 #[template(path = "burn.html")]
 pub struct Burn<'a> {
     meta: &'a env::Metadata<'a>,
+    base_path: &'static env::BasePath,
     id: String,
 }
 
@@ -144,6 +155,7 @@ impl<'a> Burn<'a> {
     pub fn new(id: String) -> Self {
         Self {
             meta: env::metadata(),
+            base_path: env::base_path(),
             id,
         }
     }

--- a/src/routes/assets.rs
+++ b/src/routes/assets.rs
@@ -33,9 +33,10 @@ fn favicon() -> impl IntoResponse {
 }
 
 pub fn routes() -> Router<AppState> {
+    let style_name = &data().style.name;
     Router::new()
         .route("/favicon.png", get(|| async { favicon() }))
-        .route(&data().style.name, get(|| async { style_css() }))
+        .route(&format!("/{style_name}"), get(|| async { style_css() }))
         .route("/dark.css", get(|| async { dark_css() }))
         .route("/light.css", get(|| async { light_css() }))
 }

--- a/src/routes/form.rs
+++ b/src/routes/form.rs
@@ -1,4 +1,5 @@
 use crate::db::write;
+use crate::env::base_path;
 use crate::id::Id;
 use crate::{pages, AppState, Error};
 use axum::extract::{Form, State};
@@ -6,8 +7,6 @@ use axum::response::Redirect;
 use axum_extra::extract::cookie::{Cookie, SignedCookieJar};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-
-use super::base_path;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Entry {
@@ -64,7 +63,6 @@ pub async fn insert(
     let mut entry: write::Entry = entry.into();
     entry.uid = Some(uid);
 
-    let base_path = base_path(&state.base_url);
     let mut url = id.to_url_path(&entry);
 
     let burn_after_reading = entry.burn_after_reading.unwrap_or(false);
@@ -72,7 +70,7 @@ pub async fn insert(
         url = format!("burn/{url}");
     }
 
-    let url_with_base = format!("{base_path}{url}");
+    let url_with_base = base_path().join(&url);
 
     state.db.insert(id, entry).await?;
 

--- a/src/routes/json.rs
+++ b/src/routes/json.rs
@@ -1,4 +1,5 @@
 use crate::db::write;
+use crate::env::base_path;
 use crate::errors::{Error, JsonErrorResponse};
 use crate::id::Id;
 use crate::AppState;
@@ -6,8 +7,6 @@ use axum::extract::State;
 use axum::Json;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-
-use super::base_path;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Entry {
@@ -50,9 +49,8 @@ pub async fn insert(
 
     let entry: write::Entry = entry.into();
 
-    let base_path = base_path(&state.base_url);
     let url = id.to_url_path(&entry);
-    let path = format!("{base_path}{url}");
+    let path = base_path().join(&url);
     state.db.insert(id, entry).await?;
 
     Ok(Json::from(RedirectResponse { path }))

--- a/src/routes/json.rs
+++ b/src/routes/json.rs
@@ -7,6 +7,8 @@ use axum::Json;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
+use super::base_path;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Entry {
     pub text: String,
@@ -47,8 +49,10 @@ pub async fn insert(
     .into();
 
     let entry: write::Entry = entry.into();
-    let path = id.to_url_path(&entry);
 
+    let base_path = base_path(&state.base_url);
+    let url = id.to_url_path(&entry);
+    let path = format!("{base_path}{url}");
     state.db.insert(id, entry).await?;
 
     Ok(Json::from(RedirectResponse { path }))

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,21 +2,11 @@ use crate::pages::{Burn, Index};
 use crate::AppState;
 use axum::extract::Path;
 use axum::routing::{get, Router};
-use url::Url;
 
 mod assets;
 mod form;
 mod json;
 pub(crate) mod paste;
-
-pub const DEFAULT_BASE_PATH: &str = "/";
-
-pub fn base_path(base_url: &Option<Url>) -> &str {
-    match base_url {
-        Some(base_url) => base_url.path(),
-        None => DEFAULT_BASE_PATH,
-    }
-}
 
 pub fn routes() -> Router<AppState> {
     Router::new()

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,11 +2,21 @@ use crate::pages::{Burn, Index};
 use crate::AppState;
 use axum::extract::Path;
 use axum::routing::{get, Router};
+use url::Url;
 
 mod assets;
 mod form;
 mod json;
 pub(crate) mod paste;
+
+pub const DEFAULT_BASE_PATH: &str = "/";
+
+pub fn base_path(base_url: &Option<Url>) -> &str {
+    match base_url {
+        Some(base_url) => base_url.path(),
+        None => DEFAULT_BASE_PATH,
+    }
+}
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -28,6 +38,8 @@ mod tests {
     use http::StatusCode;
     use reqwest::header;
     use serde::Serialize;
+
+    // TODO: Add tests for base path
 
     #[tokio::test]
     async fn unknown_paste() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/routes/paste.rs
+++ b/src/routes/paste.rs
@@ -16,6 +16,8 @@ use axum_extra::headers::{HeaderMapExt, HeaderValue};
 use serde::Deserialize;
 use url::Url;
 
+use super::base_path;
+
 #[derive(Deserialize, Debug)]
 pub enum Format {
     #[serde(rename(deserialize = "raw"))]
@@ -232,5 +234,5 @@ pub async fn delete(
 
     state.db.delete(id).await?;
 
-    Ok(Redirect::to("/"))
+    Ok(Redirect::to(base_path(&state.base_url)))
 }

--- a/src/routes/paste.rs
+++ b/src/routes/paste.rs
@@ -1,6 +1,7 @@
 use crate::cache::Key as CacheKey;
 use crate::crypto::Password;
 use crate::db::read::Entry;
+use crate::env::base_path;
 use crate::highlight::Html;
 use crate::routes::{form, json};
 use crate::{pages, AppState, Error};
@@ -15,8 +16,6 @@ use axum_extra::headers;
 use axum_extra::headers::{HeaderMapExt, HeaderValue};
 use serde::Deserialize;
 use url::Url;
-
-use super::base_path;
 
 #[derive(Deserialize, Debug)]
 pub enum Format {
@@ -234,5 +233,5 @@ pub async fn delete(
 
     state.db.delete(id).await?;
 
-    Ok(Redirect::to(base_path(&state.base_url)))
+    Ok(Redirect::to(base_path().path()))
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,5 +1,6 @@
 use crate::cache::Cache;
 use crate::db::{self, Database};
+use crate::env::base_url;
 use axum::extract::Request;
 use axum::response::Response;
 use axum::Router;
@@ -56,7 +57,7 @@ pub(crate) fn make_app() -> Result<Router, Box<dyn std::error::Error>> {
     let db = Database::new(db::Open::Memory)?;
     let cache = Cache::new(NonZeroUsize::new(128).unwrap());
     let key = Key::generate();
-    let base_url = None;
+    let base_url = base_url().unwrap();
     let state = crate::AppState {
         db,
         cache,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -64,5 +64,5 @@ pub(crate) fn make_app() -> Result<Router, Box<dyn std::error::Error>> {
         base_url,
     };
 
-    Ok(crate::make_app(4096, Duration::new(30, 0), &None).with_state(state))
+    Ok(crate::make_app(4096, Duration::new(30, 0)).with_state(state))
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -64,5 +64,5 @@ pub(crate) fn make_app() -> Result<Router, Box<dyn std::error::Error>> {
         base_url,
     };
 
-    Ok(crate::make_app(4096, Duration::new(30, 0)).with_state(state))
+    Ok(crate::make_app(4096, Duration::new(30, 0), &None).with_state(state))
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,13 +5,13 @@
     <meta name="generator" content="wastebin {{ meta.version }}"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <title>{{ meta.title }}</title>
-    <link rel="stylesheet" href="{{ meta.base_path }}{{ meta.highlight.style.name }}">
-    <link rel="icon" href="{{ meta.base_path }}favicon.png" type="image/png">
+    <link rel="stylesheet" href="{{ base_path.join(meta.highlight.style.name) }}">
+    <link rel="icon" href="{{ base_path.join("favicon.png") }}" type="image/png">
     {% block head %}{% endblock %}
   </head>
   <body>
     <header>
-            <span id="nav-title"><a href="{{ meta.base_path }}"><button>home</button></a></span>
+            <span id="nav-title"><a href="{{ base_path.path() }}"><button>home</button></a></span>
       <nav>
         <ul>
           {% block nav %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,13 +5,13 @@
     <meta name="generator" content="wastebin {{ meta.version }}"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <title>{{ meta.title }}</title>
-    <link rel="stylesheet" href="{{ meta.highlight.style.name }}">
-    <link rel="icon" href="/favicon.png" type="image/png">
+    <link rel="stylesheet" href="{{ meta.base_path }}{{ meta.highlight.style.name }}">
+    <link rel="icon" href="{{ meta.base_path }}favicon.png" type="image/png">
     {% block head %}{% endblock %}
   </head>
   <body>
     <header>
-      <span id="nav-title"><a href="/"><button>home</button></a></span>
+            <span id="nav-title"><a href="{{ meta.base_path }}"><button>home</button></a></span>
       <nav>
         <ul>
           {% block nav %}{% endblock %}

--- a/templates/burn.html
+++ b/templates/burn.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
   <div class="center">
-    <p class="text-center">Copy and send <a class="punctuation definition tag" href="/{{ id }}">this link</a>.
+    <p class="text-center">Copy and send <a class="punctuation definition tag" href="{{  meta.base_path }}{{ id }}">this link</a>.
     After opening it for the first time, it will be deleted.</p>
   </div>
 {% endblock %}

--- a/templates/burn.html
+++ b/templates/burn.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
   <div class="center">
-    <p class="text-center">Copy and send <a class="punctuation definition tag" href="{{  meta.base_path }}{{ id }}">this link</a>.
+    <p class="text-center">Copy and send <a class="punctuation definition tag" href="{{  base_path.join(id) }}">this link</a>.
     After opening it for the first time, it will be deleted.</p>
   </div>
 {% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -2,6 +2,6 @@
 {% block content %}
   <div class="center">
     <p class="text-center">😢 {{ error }}</p>
-    <p class="text-center"><a class="punctuation definition tag" href="{{ meta.base_path }}">go back</a></p>
+    <p class="text-center"><a class="punctuation definition tag" href="{{ base_path.path() }}">go back</a></p>
   </div>
 {% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -2,6 +2,6 @@
 {% block content %}
   <div class="center">
     <p class="text-center">😢 {{ error }}</p>
-    <p class="text-center"><a class="punctuation definition tag" href="/">go back</a></p>
+    <p class="text-center"><a class="punctuation definition tag" href="./">go back</a></p>
   </div>
 {% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -2,6 +2,6 @@
 {% block content %}
   <div class="center">
     <p class="text-center">😢 {{ error }}</p>
-    <p class="text-center"><a class="punctuation definition tag" href="./">go back</a></p>
+    <p class="text-center"><a class="punctuation definition tag" href="{{ meta.base_path }}">go back</a></p>
   </div>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,7 @@
 {% endblock %}
 
 {%- block content -%}
-    <form action="{{ meta.base_path }}" method="post">
+    <form action="{{ base_path.path() }}" method="post">
       <div class="container">
         <div class="content">
           <textarea id="text" name="text" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" autofocus></textarea>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,7 @@
 {% endblock %}
 
 {%- block content -%}
-    <form action="/" method="post">
+    <form action="{{ meta.base_path }}" method="post">
       <div class="container">
         <div class="content">
           <textarea id="text" name="text" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" autofocus></textarea>

--- a/templates/paste.html
+++ b/templates/paste.html
@@ -6,22 +6,22 @@
 
   function onKey(e) {
     if (e.key == 'n') {
-      window.location.href = '{{ meta.base_path }}';
+      window.location.href = '{{ base_path.path() }}';
     }
     else if (e.key == 'r') {
-      window.location.href = '{{ meta.base_path }}{{ id }}?fmt=raw';
+      window.location.href = '{{ base_path.join(id) }}?fmt=raw';
     }
     else if (e.key == 'y') {
       navigator.clipboard.writeText(window.location.href);
     }
     else if (e.key == 'd') {
-      window.location.href = '{{ meta.base_path }}{{ id }}?dl={{ ext }}';
+      window.location.href = '{{ base_path.join(id) }}?dl={{ ext }}';
     }
     else if (e.key == 'q') {
-      window.location.href = '{{ meta.base_path }}{{ id }}?fmt=qr';
+      window.location.href = '{{ base_path.join(id) }}?fmt=qr';
     }
     else if (e.key == 'p') {
-      window.location.href = '{{ meta.base_path }}{{ id }}';
+      window.location.href = '{{ base_path.join(id) }}';
     }
     else if (e.key == '?') {
       var overlay = document.getElementById("overlay");
@@ -47,8 +47,8 @@
 
 {% block nav %}
   {% if can_delete %}
-    <li><a href="{{ meta.base_path }}delete/{{ id }}"><button>delete</button></a></li>
+    <li><a href="{{ base_path.join("delete/") }}{{ id }}"><button>delete</button></a></li>
   {% endif %}
-    <li><a href="{{ meta.base_path }}{{ id }}?dl={{ ext }}"><button>download</button></a></li>
-    <li><a href="{{ meta.base_path }}{{ id }}?fmt=raw"><button>raw</button></a></li>
+    <li><a href="{{ base_path.join(id) }}?dl={{ ext }}"><button>download</button></a></li>
+    <li><a href="{{ base_path.join(id) }}?fmt=raw"><button>raw</button></a></li>
 {% endblock %}

--- a/templates/paste.html
+++ b/templates/paste.html
@@ -6,22 +6,22 @@
 
   function onKey(e) {
     if (e.key == 'n') {
-      window.location.href = '/';
+      window.location.href = '{{ meta.base_path }}';
     }
     else if (e.key == 'r') {
-      window.location.href = '/{{ id }}?fmt=raw';
+      window.location.href = '{{ meta.base_path }}{{ id }}?fmt=raw';
     }
     else if (e.key == 'y') {
       navigator.clipboard.writeText(window.location.href);
     }
     else if (e.key == 'd') {
-      window.location.href = '/{{ id }}?dl={{ ext }}';
+      window.location.href = '{{ meta.base_path }}{{ id }}?dl={{ ext }}';
     }
     else if (e.key == 'q') {
-      window.location.href = '/{{ id }}?fmt=qr';
+      window.location.href = '{{ meta.base_path }}{{ id }}?fmt=qr';
     }
     else if (e.key == 'p') {
-      window.location.href = '/{{ id }}';
+      window.location.href = '{{ meta.base_path }}{{ id }}';
     }
     else if (e.key == '?') {
       var overlay = document.getElementById("overlay");
@@ -47,8 +47,8 @@
 
 {% block nav %}
   {% if can_delete %}
-    <li><a href="/delete/{{ id }}"><button>delete</button></a></li>
+    <li><a href="{{ meta.base_path }}delete/{{ id }}"><button>delete</button></a></li>
   {% endif %}
-    <li><a href="/{{ id }}?dl={{ ext }}"><button>download</button></a></li>
-    <li><a href="/{{ id }}?fmt=raw"><button>raw</button></a></li>
+    <li><a href="{{ meta.base_path }}{{ id }}?dl={{ ext }}"><button>download</button></a></li>
+    <li><a href="{{ meta.base_path }}{{ id }}?fmt=raw"><button>raw</button></a></li>
 {% endblock %}


### PR DESCRIPTION
Hi there! 👋

I took a shot at letting `wastebin` work when served from a sub-path (e.g. https://example.com/wastsebin/). It's a WIP, but I thought of getting this out early and discuss 1. if useful; 2. improvements.

The idea is to re-use the `WASTEBIN_BASE_URL` variable and get its `path` component (if any).

Right now:
- [X] Existing tests pass.
- [X] It works™.
- [x] If required, clean-up.
- [x] Add tests for the sub-path implementation. 

What's the best approach to add the test? Duplicate them? Run them in a `for` loop with / without the sub-path?
Also, I am not convinced of storing the base path in the `metadata` as a static variable. Are there other approaches?