### PR TITLE
Reduce lang list size to fix overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/src/themes/style.css
+++ b/src/themes/style.css
@@ -38,7 +38,7 @@ body {
   font-family: "JetBrains Mono", monospace;
   padding: 0;
   margin: 0;
-  height: calc(100vh - 55px);
+  height: 90dvh;
 }
 
 header {
@@ -143,7 +143,7 @@ a, a:visited, a:hover {
   height: 100%;
   align-items: stretch;
   justify-items: stretch;
-  margin: 0em 2em;
+  margin: 1em 2em 0em 2em;
 }
 
 .content {
@@ -168,7 +168,6 @@ a, a:visited, a:hover {
 }
 
 .extensions-list {
-  padding-top: 1em;
   grid-row: 1/2;
 }
 

--- a/src/themes/style.css
+++ b/src/themes/style.css
@@ -38,6 +38,7 @@ body {
   font-family: "JetBrains Mono", monospace;
   padding: 0;
   margin: 0;
+  height: calc(100vh - 55px);
 }
 
 header {
@@ -139,10 +140,10 @@ a, a:visited, a:hover {
   grid-template-columns: 4fr 1fr;
   grid-template-rows: 1fr 1fr 1fr 1fr 20fr;
   grid-gap: 2em;
-  height: 96vh;
+  height: 100%;
   align-items: stretch;
   justify-items: stretch;
-  margin: 1em 2em 0em 2em;
+  margin: 0em 2em;
 }
 
 .content {
@@ -158,6 +159,8 @@ a, a:visited, a:hover {
   line-height: 1.6rem;
   font-size: 1rem;
   resize: none;
+  padding: 0;
+  margin: 0;
 }
 
 .content > textarea:focus {
@@ -165,6 +168,7 @@ a, a:visited, a:hover {
 }
 
 .extensions-list {
+  padding-top: 1em;
   grid-row: 1/2;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,13 +58,13 @@
 {% endblock %}
 
 {%- block content -%}
-    <form action="{{ base_path.path() }}" method="post">
+    <form action="{{ base_path.path() }}" method="post" style="height: 100%;">
       <div class="container">
         <div class="content">
           <textarea id="text" name="text" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" autofocus></textarea>
         </div>
         <div class="extensions-list">
-          <select name="extension" id="langs" size="23">
+          <select name="extension" id="langs" size="17">
           {%- for syntax in meta.highlight.syntaxes -%}
             {%- if syntax.file_extensions.len() > 0 %}
             <option value="{{ syntax.file_extensions.first().unwrap() }}">{{ syntax.name }}</option>


### PR DESCRIPTION
A scrollbar was getting introduced due to the size of the langs list. This reduces the size from 23 options to 17 options, and also adjusts some height attributes in other elements to remove the scrollbar completely.