### PR TITLE
Add maximum expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ run-time behavior:
   until wastebin responds with 408, by default it is set to 5 seconds.
 * `WASTEBIN_MAX_BODY_SIZE` number of bytes to accept for POST requests. Defaults
   to 1 MB.
+* `WASTEBIN_MAX_PASTE_EXPIRY` maximum allowed lifetime of a paste. Leave empty or set to -1 for no limit. Defaults to no limit.
 * `WASTEBIN_PASSWORD_SALT` salt used to hash user passwords used for encrypting
   pastes.
 * `WASTEBIN_SIGNING_KEY` sets the key to sign cookies. If not set, a random key

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ run-time behavior:
   until wastebin responds with 408, by default it is set to 5 seconds.
 * `WASTEBIN_MAX_BODY_SIZE` number of bytes to accept for POST requests. Defaults
   to 1 MB.
-* `WASTEBIN_MAX_PASTE_EXPIRY` maximum allowed lifetime of a paste. Leave empty or set to -1 for no limit. Defaults to no limit.
+* `WASTEBIN_MAX_PASTE_EXPIRATION` maximum allowed lifetime of a paste in seconds. Leave empty or set to -1 for no limit. Defaults to no limit.
 * `WASTEBIN_PASSWORD_SALT` salt used to hash user passwords used for encrypting
   pastes.
 * `WASTEBIN_SIGNING_KEY` sets the key to sign cookies. If not set, a random key

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ pub struct AppState {
     cache: Cache,
     key: Key,
     base_url: Option<Url>,
+    max_expiry: Option<u32>,
 }
 
 impl FromRef<AppState> for Key {
@@ -91,6 +92,8 @@ async fn start() -> Result<(), Box<dyn std::error::Error>> {
     let max_body_size = env::max_body_size()?;
     let base_url = env::base_url()?;
     let timeout = env::http_timeout()?;
+    let max_expiry = env::max_paste_expiry();
+
     let cache = Cache::new(cache_size);
     let db = Database::new(method)?;
     let state = AppState {
@@ -98,6 +101,7 @@ async fn start() -> Result<(), Box<dyn std::error::Error>> {
         cache,
         key,
         base_url,
+        max_expiry,
     };
 
     tracing::debug!("serving on {addr}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ pub struct AppState {
     cache: Cache,
     key: Key,
     base_url: Option<Url>,
-    max_expiry: Option<u32>,
+    max_expiration: Option<u32>,
 }
 
 impl FromRef<AppState> for Key {
@@ -92,7 +92,7 @@ async fn start() -> Result<(), Box<dyn std::error::Error>> {
     let max_body_size = env::max_body_size()?;
     let base_url = env::base_url()?;
     let timeout = env::http_timeout()?;
-    let max_expiry = env::max_paste_expiry();
+    let max_expiration = env::max_paste_expiration()?;
 
     let cache = Cache::new(cache_size);
     let db = Database::new(method)?;
@@ -101,7 +101,7 @@ async fn start() -> Result<(), Box<dyn std::error::Error>> {
         cache,
         key,
         base_url,
-        max_expiry,
+        max_expiration,
     };
 
     tracing::debug!("serving on {addr}");

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,5 +1,3 @@
-use std::cell::Cell;
-
 use crate::cache::Key as CacheKey;
 use crate::env;
 use crate::highlight::Html;
@@ -37,10 +35,7 @@ impl From<crate::Error> for ErrorResponse<'_> {
 pub struct Index<'a> {
     meta: &'a env::Metadata<'a>,
     base_path: &'static env::BasePath,
-    max_expiry: Option<u32>,
-
-    /// SAFETY: calls in the template are always sequential
-    default_has_been_written: Cell<bool>,
+    max_expiration: Option<u32>,
 }
 
 impl<'a> Default for Index<'a> {
@@ -48,60 +43,66 @@ impl<'a> Default for Index<'a> {
         Self {
             meta: env::metadata(),
             base_path: env::base_path(),
-            max_expiry: env::max_paste_expiry(),
-            default_has_been_written: Cell::new(false),
+            // exception should already have been handled in main
+            max_expiration: env::max_paste_expiration().unwrap(),
         }
     }
 }
 
-#[derive(Debug)]
-enum Expiry<'a> {
-    Special(&'a str),
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Expiration {
+    None,
+    Burn,
     Time(u32),
 }
 
-impl<'a> Expiry<'a> {
-    fn as_str(&self) -> String {
+impl std::fmt::Display for Expiration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Expiry::Special(s) => s.to_string(),
-            Expiry::Time(u) => u.to_string(),
+            Expiration::None => write!(f, ""),
+            Expiration::Burn => write!(f, "burn"),
+            Expiration::Time(t) => write!(f, "{}", t),
         }
     }
 }
 
-impl<'a> Index<'a> {
-    fn expiry(&self, name: &str, time: Expiry<'a>) -> String {
-        let sel_string = if self.default_has_been_written.get() {
-            ""
-        } else {
-            r#" selected"#
-        };
+const EXPIRATION_OPTIONS: [(&'static str, Expiration); 8] = [
+    ("never", Expiration::None),
+    ("10 minutes", Expiration::Time(600)),
+    ("1 hour", Expiration::Time(3600)),
+    ("1 day", Expiration::Time(86400)),
+    ("1 week", Expiration::Time(604800)),
+    ("1 month", Expiration::Time(2592000)),
+    ("1 year", Expiration::Time(31536000)),
+    ("🔥 after reading", Expiration::Burn),
+];
 
-        match self.max_expiry {
-            Some(exp) => {
-                match time {
-                    // never emit an never expire with a limit
-                    Expiry::Special("") => String::new(),
-                    Expiry::Special("burn") => {
-                        self.default_has_been_written.set(true);
-                        format!(r#"<option{} value="burn">{}</option>"#, sel_string, name)
-                    }
-                    Expiry::Special(_) => String::new(),
-                    Expiry::Time(t) if t > exp => String::new(),
-                    Expiry::Time(t) => {
-                        self.default_has_been_written.set(true);
-                        format!(r#"<option{} value="{}">{}</option>"#, sel_string, t, name)
-                    }
+impl<'a> Index<'a> {
+    fn expiry_options(&self) -> String {
+        let mut option_set = String::new();
+        let mut wrote_first = false;
+
+        option_set.push('\n');
+
+        for (opt_name, opt_val) in EXPIRATION_OPTIONS {
+            if self.max_expiration.is_none()
+                || opt_val == Expiration::Burn
+                || matches!((self.max_expiration, opt_val), (Some(exp), Expiration::Time(time)) if time <= exp)
+            {
+                option_set.push_str("<option");
+                if !wrote_first {
+                    option_set.push_str(" selected");
+                    wrote_first = true;
                 }
-            }
-            None => {
-                self.default_has_been_written.set(true);
-                format!(
-                    r#"<option{} value="{}">{}</option>"#,
-                    sel_string, time, name
-                )
+                option_set.push_str(" value=\"");
+                option_set.push_str(opt_val.to_string().as_ref());
+                option_set.push_str("\">");
+                option_set.push_str(opt_name);
+                option_set.push_str("</option>\n");
             }
         }
+
+        option_set
     }
 }
 

--- a/src/routes/form.rs
+++ b/src/routes/form.rs
@@ -72,7 +72,7 @@ pub async fn insert(
 
     let url_with_base = base_path().join(&url);
 
-    if let Some(max_exp) = state.max_expiry {
+    if let Some(max_exp) = state.max_expiration {
         entry.expires = entry
             .expires
             .map_or_else(|| Some(max_exp), |value| Some(value.min(max_exp)));

--- a/src/routes/form.rs
+++ b/src/routes/form.rs
@@ -72,6 +72,12 @@ pub async fn insert(
 
     let url_with_base = base_path().join(&url);
 
+    if let Some(max_exp) = state.max_expiry {
+        entry.expires = entry
+            .expires
+            .map_or_else(|| Some(max_exp), |value| Some(value.min(max_exp)));
+    }
+
     state.db.insert(id, entry).await?;
 
     let jar = jar.add(Cookie::new("uid", uid.to_string()));

--- a/src/routes/json.rs
+++ b/src/routes/json.rs
@@ -49,7 +49,7 @@ pub async fn insert(
 
     let mut entry: write::Entry = entry.into();
 
-    if let Some(max_exp) = state.max_expiry {
+    if let Some(max_exp) = state.max_expiration {
         entry.expires = entry
             .expires
             .map_or_else(|| Some(max_exp), |value| Some(value.min(max_exp)));

--- a/src/routes/json.rs
+++ b/src/routes/json.rs
@@ -47,7 +47,13 @@ pub async fn insert(
     .map_err(Error::from)?
     .into();
 
-    let entry: write::Entry = entry.into();
+    let mut entry: write::Entry = entry.into();
+
+    if let Some(max_exp) = state.max_expiry {
+        entry.expires = entry
+            .expires
+            .map_or_else(|| Some(max_exp), |value| Some(value.min(max_exp)));
+    }
 
     let url = id.to_url_path(&entry);
     let path = base_path().join(&url);

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -63,6 +63,7 @@ pub(crate) fn make_app() -> Result<Router, Box<dyn std::error::Error>> {
         cache,
         key,
         base_url,
+        max_expiry: None,
     };
 
     Ok(crate::make_app(4096, Duration::new(30, 0)).with_state(state))

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -63,7 +63,7 @@ pub(crate) fn make_app() -> Result<Router, Box<dyn std::error::Error>> {
         cache,
         key,
         base_url,
-        max_expiry: None,
+        max_expiration: None,
     };
 
     Ok(crate::make_app(4096, Duration::new(30, 0)).with_state(state))

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,14 +76,8 @@
           <input type="search" id="filter" placeholder="Filter ..." onchange="filterLangs(event);" onkeyup="filterLangs(event)"></input>
         </div>
         <div class="expiration-list">
-          <select name="expires" size="7">
-            {{ Self::expiry(self, "never",      Expiry::Special(""))|safe }}
-            {{ Self::expiry(self, "10 minutes", Expiry::Time(600))|safe }}
-            {{ Self::expiry(self, "1 hour",     Expiry::Time(3600))|safe }}
-            {{ Self::expiry(self, "1 day",      Expiry::Time(86400))|safe }}
-            {{ Self::expiry(self, "1 week",     Expiry::Time(604800))|safe }}
-            {{ Self::expiry(self, "1 year",     Expiry::Time(215308800))|safe }}
-            {{ Self::expiry(self, "burn",       Expiry::Special("burn"))|safe }}
+          <select name="expires" size="8">
+            {{- Self::expiry_options(self)|safe }}
           </select>
         </div>
         <div class="password">

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,13 +77,13 @@
         </div>
         <div class="expiration-list">
           <select name="expires" size="7">
-            <option selected="" value="">never</option>
-            <option value="600">10 minutes</option>
-            <option value="3600">1 hour</option>
-            <option value="86400">1 day</option>
-            <option value="604800">1 week</option>
-            <option value="215308800">1 year</option>
-            <option value="burn">🔥 after reading</option>
+            {{ Self::expiry(self, "never",      Expiry::Special(""))|safe }}
+            {{ Self::expiry(self, "10 minutes", Expiry::Time(600))|safe }}
+            {{ Self::expiry(self, "1 hour",     Expiry::Time(3600))|safe }}
+            {{ Self::expiry(self, "1 day",      Expiry::Time(86400))|safe }}
+            {{ Self::expiry(self, "1 week",     Expiry::Time(604800))|safe }}
+            {{ Self::expiry(self, "1 year",     Expiry::Time(215308800))|safe }}
+            {{ Self::expiry(self, "burn",       Expiry::Special("burn"))|safe }}
           </select>
         </div>
         <div class="password">


### PR DESCRIPTION
This aims to implement #54, and also be an improvement over #55.

Changes Made:

- Add ~`WASTEBIN_MAX_PASTE_EXPIRY`~ `WASTEBIN_MAX_PASTE_EXPIRATION`
- Ensure both the form and json routes honor the set limit (if any) (currently not done by #55)
  - ~Currently it simply clamps the expiry time~
  - Invalid values or too large values will cause an error
- Remove invalid options from the new-paste UI
  - Correctly hide `never expire` if any limit is set
  - Always show `burn`, even if the limit is 0
  - Default select the "top" most expiry (either "never", or 10 minutes)