### PR TITLE
Make use of NonZero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Use NonZero internally for data where 0 is not a valid value and
+  any special meaning in expressed via an outer Option.
+
 
 ## 2.5.0
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ run-time behavior:
 * `WASTEBIN_MAX_BODY_SIZE` number of bytes to accept for POST requests. Defaults
   to 1 MB.
 * `WASTEBIN_MAX_PASTE_EXPIRATION` maximum allowed lifetime of a paste in
-  seconds. Defaults to unlimited.
+  seconds. Defaults to 0 meaning unlimited.
 * `WASTEBIN_PASSWORD_SALT` salt used to hash user passwords used for encrypting
   pastes.
 * `WASTEBIN_SIGNING_KEY` sets the key to sign cookies. If not set, a random key

--- a/src/db.rs
+++ b/src/db.rs
@@ -68,6 +68,7 @@ pub mod write {
     use async_compression::tokio::bufread::ZstdEncoder;
     use serde::{Deserialize, Serialize};
     use std::io::Cursor;
+    use std::num::NonZeroU32;
     use tokio::io::{AsyncReadExt, BufReader};
 
     /// An uncompressed entry to be inserted into the database.
@@ -78,7 +79,7 @@ pub mod write {
         /// File extension
         pub extension: Option<String>,
         /// Expiration in seconds from now
-        pub expires: Option<u32>,
+        pub expires: Option<NonZeroU32>,
         /// Delete if read
         pub burn_after_reading: Option<bool>,
         /// User identifier that inserted the entry
@@ -364,6 +365,8 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZero;
+
     use super::*;
 
     fn new_db() -> Result<Database, Box<dyn std::error::Error>> {
@@ -399,7 +402,7 @@ mod tests {
         let db = new_db()?;
 
         let entry = write::Entry {
-            expires: Some(1),
+            expires: Some(NonZero::new(1).unwrap()),
             ..Default::default()
         };
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -2,7 +2,7 @@ use crate::{db, highlight};
 use axum_extra::extract::cookie::Key;
 use std::env::VarError;
 use std::net::SocketAddr;
-use std::num::{NonZeroUsize, ParseIntError};
+use std::num::{NonZero, NonZeroU32, NonZeroUsize, ParseIntError};
 use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -178,9 +178,10 @@ pub fn http_timeout() -> Result<Duration, Error> {
         .map_err(Error::HttpTimeout)
 }
 
-pub fn max_paste_expiration() -> Result<Option<u32>, Error> {
+pub fn max_paste_expiration() -> Result<Option<NonZeroU32>, Error> {
     std::env::var(VAR_MAX_PASTE_EXPIRATION)
         .ok()
         .map(|value| value.parse::<u32>().map_err(Error::MaxPasteExpiration))
         .transpose()
+        .map(|op| op.and_then(NonZero::new))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use crate::errors::Error;
 use axum::extract::{DefaultBodyLimit, FromRef};
 use axum::Router;
 use axum_extra::extract::cookie::Key;
+use std::num::NonZeroU32;
 use std::process::ExitCode;
 use std::time::Duration;
 use tokio::net::TcpListener;
@@ -32,7 +33,7 @@ pub struct AppState {
     cache: Cache,
     key: Key,
     base_url: Option<Url>,
-    max_expiration: Option<u32>,
+    max_expiration: Option<NonZeroU32>,
 }
 
 impl FromRef<AppState> for Key {

--- a/src/routes/form.rs
+++ b/src/routes/form.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use crate::db::write;
 use crate::env::BASE_PATH;
 use crate::id::Id;
@@ -21,8 +23,8 @@ impl From<Entry> for write::Entry {
         let burn_after_reading = Some(entry.expires == "burn");
         let password = (!entry.password.is_empty()).then_some(entry.password);
 
-        let expires = match entry.expires.parse::<u32>() {
-            Ok(0) | Err(_) => None,
+        let expires = match entry.expires.parse::<NonZeroU32>() {
+            Err(_) => None,
             Ok(secs) => Some(secs),
         };
 

--- a/src/routes/json.rs
+++ b/src/routes/json.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use crate::db::write;
 use crate::env::BASE_PATH;
 use crate::errors::{Error, JsonErrorResponse};
@@ -12,7 +14,7 @@ use serde::{Deserialize, Serialize};
 pub struct Entry {
     pub text: String,
     pub extension: Option<String>,
-    pub expires: Option<u32>,
+    pub expires: Option<NonZeroU32>,
     pub burn_after_reading: Option<bool>,
     pub password: Option<String>,
 }


### PR DESCRIPTION
Make clear to readers that the value 0 is not supported and has no special meaning.

Also allows the compiler to improve enum layouts.