### PR TITLE
Show QR code after a burn paste has been created

### DIFF
--- a/src/pages.rs
+++ b/src/pages.rs
@@ -164,6 +164,15 @@ impl<'a> Encrypted<'a> {
     }
 }
 
+/// Return module coordinates that are dark.
+fn dark_modules(code: &qrcodegen::QrCode) -> Vec<(i32, i32)> {
+    let size = code.size();
+    (0..size)
+        .flat_map(|x| (0..size).map(move |y| (x, y)))
+        .filter(|(x, y)| code.get_module(*x, *y))
+        .collect()
+}
+
 /// Paste view showing the formatted paste as well as a bunch of links.
 #[derive(Template)]
 #[template(path = "qr.html", escape = "none")]
@@ -189,32 +198,33 @@ impl<'a> Qr<'a> {
         }
     }
 
-    // Return module coordinates that are dark.
     fn dark_modules(&self) -> Vec<(i32, i32)> {
-        let size = self.code.size();
-        (0..size)
-            .flat_map(|x| (0..size).map(move |y| (x, y)))
-            .filter(|(x, y)| self.code.get_module(*x, *y))
-            .collect()
+        dark_modules(&self.code)
     }
 }
 
 /// Burn page shown if "burn-after-reading" was selected during insertion.
 #[derive(Template)]
-#[template(path = "burn.html")]
+#[template(path = "burn.html", escape = "none")]
 pub struct Burn<'a> {
     meta: &'a env::Metadata<'a>,
     base_path: &'static env::BasePath,
     id: String,
+    code: qrcodegen::QrCode,
 }
 
 impl<'a> Burn<'a> {
     /// Construct new burn page linking to `id`.
-    pub fn new(id: String) -> Self {
+    pub fn new(code: qrcodegen::QrCode, id: String) -> Self {
         Self {
             meta: &env::METADATA,
             base_path: &env::BASE_PATH,
             id,
+            code,
         }
+    }
+
+    fn dark_modules(&self) -> Vec<(i32, i32)> {
+        dark_modules(&self.code)
     }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,6 +1,6 @@
-use crate::pages::{Burn, Index};
+use crate::pages::Index;
 use crate::AppState;
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::routing::{get, Router};
 
 mod assets;
@@ -19,7 +19,7 @@ pub fn routes() -> Router<AppState> {
             "/:id",
             get(paste::get).post(paste::get).delete(paste::delete),
         )
-        .route("/burn/:id", get(|Path(id)| async { Burn::new(id) }))
+        .route("/burn/:id", get(paste::burn_created))
         .route("/delete/:id", get(paste::delete))
         .merge(assets::routes())
 }

--- a/templates/burn.html
+++ b/templates/burn.html
@@ -3,5 +3,11 @@
   <div class="center">
     <p class="text-center">Copy and send <a class="punctuation definition tag" href="{{  base_path.join(id) }}">this link</a>.
     After opening it for the first time, it will be deleted.</p>
+    <p class="text-center">
+    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 {{ code.size() + 4 }} {{ code.size() + 4 }}" stroke="none" width="16rem">
+      <rect width="100%" height="100%" fill="#fafafa"/>
+      <path d="{% for (x, y) in self.dark_modules() %}M{{ x + 2 }},{{ y + 2 }}h1v1h-1z {% endfor %}" fill="#000000"/>
+    </svg>
+    </p>
   </div>
 {% endblock %}


### PR DESCRIPTION
Since one can not visit the actual page (without deleting it) for one-time-pastes, there is no other way to get the QR code for URL of the created paste.