### PR TITLE
Expand ID range to harden brute forcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Breaking**: Expand the domain for IDs from 2^32 to 2^64,
+  resulting in keys of length 11 instead of 6.
+  Old 6 character keys are still accepted for existing links.
+  Existing Database entries are not affected.
+
 
 ## 2.7.0
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -60,14 +60,32 @@ mod tests {
 
     #[test]
     fn cache_key() {
+        /*
+         * Support ID generated in the old 32-bit format
+         */
+
         let key = Key::from_str("bJZCna").unwrap();
-        assert_eq!(key.id(), "bJZCna");
+        assert_eq!(key.id(), "aaaaaay83de");
         assert_eq!(key.id, 104651828.into());
         assert_eq!(key.ext, "txt");
 
         let key = Key::from_str("sIiFec.rs").unwrap();
-        assert_eq!(key.id(), "sIiFec");
+        assert_eq!(key.id(), "aaaaaeOIhXc");
         assert_eq!(key.id, 1243750162.into());
+        assert_eq!(key.ext, "rs");
+
+        /*
+         * Support new 64-bit format
+         */
+
+        let key = Key::from_str("bJZCna1237p").unwrap();
+        assert_eq!(key.id(), "bJZCna1237p");
+        assert_eq!(key.id, 449476178952511423.into());
+        assert_eq!(key.ext, "txt");
+
+        let key = Key::from_str("-IiFec1237p.rs").unwrap();
+        assert_eq!(key.id(), "-IiFec1237p");
+        assert_eq!(key.id, (-422741260676702273).into());
         assert_eq!(key.ext, "rs");
 
         assert!(Key::from_str("foo").is_err());

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,24 +1,23 @@
 use crate::db::write::Entry;
 use crate::errors::Error;
+use core::str;
 use std::fmt;
 use std::str::FromStr;
 
-const CHAR_TABLE: &[char; 64] = &[
-    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
-    't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4',
-    '5', '6', '7', '8', '9', '-', '+',
-];
+const CHAR_TABLE: &[u8; 64] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+";
 
-/// Represents a 32-bit integer either numerically or mapped to a 6 character string.
+pub type Inner = i64;
+const ID_LENGTH: usize = 11;
+
+/// Represents a 64-bit integer either numerically or mapped to a 11 character string.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Id {
-    n: u32,
+    n: Inner,
 }
 
 impl Id {
     /// Return the value itself.
-    pub fn as_u32(self) -> u32 {
+    pub fn as_inner(self) -> Inner {
         self.n
     }
 
@@ -33,16 +32,25 @@ impl Id {
 
 impl fmt::Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut s = String::with_capacity(6);
+        #[allow(clippy::cast_sign_loss)]
+        let buf: [u8; ID_LENGTH] = [
+            CHAR_TABLE[((self.n >> 58) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 52) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 46) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 40) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 34) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 28) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 22) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 16) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 10) & 0x3f) as usize],
+            CHAR_TABLE[((self.n >> 4) & 0x3f) as usize],
+            CHAR_TABLE[(self.n & 0xf) as usize],
+        ];
 
-        s.push(CHAR_TABLE[((self.n >> 26) & 0x3f) as usize]);
-        s.push(CHAR_TABLE[((self.n >> 20) & 0x3f) as usize]);
-        s.push(CHAR_TABLE[((self.n >> 14) & 0x3f) as usize]);
-        s.push(CHAR_TABLE[((self.n >> 8) & 0x3f) as usize]);
-        s.push(CHAR_TABLE[((self.n >> 2) & 0x3f) as usize]);
-        s.push(CHAR_TABLE[(self.n & 0x3) as usize]);
+        let str = str::from_utf8(&buf).expect("characters are valid UTF-8");
+        debug_assert!(str.len() == ID_LENGTH);
 
-        write!(f, "{s}")
+        write!(f, "{str}")
     }
 }
 
@@ -50,24 +58,48 @@ impl FromStr for Id {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if value.len() != 6 {
+        /* Support ID generated in the old 32-bit format */
+        if value.len() == 6 {
+            let mut n: Inner = 0;
+
+            for (pos, char) in value.as_bytes().iter().enumerate() {
+                let bits: Option<Inner> = CHAR_TABLE.iter().enumerate().find_map(|(bits, c)| {
+                    (char == c).then(|| bits.try_into().expect("bits not 64 bits"))
+                });
+
+                match bits {
+                    None => return Err(Error::IllegalCharacters),
+                    Some(bits) => {
+                        if pos < 5 {
+                            n = (n << 6) | bits;
+                        } else {
+                            n = (n << 2) | bits;
+                        }
+                    }
+                }
+            }
+
+            return Ok(Self { n });
+        }
+
+        if value.len() != ID_LENGTH {
             return Err(Error::WrongSize);
         }
 
-        let mut n: u32 = 0;
+        let mut n: Inner = 0;
 
-        for (pos, char) in value.chars().enumerate() {
-            let bits: Option<u32> = CHAR_TABLE.iter().enumerate().find_map(|(bits, c)| {
-                (char == *c).then(|| bits.try_into().expect("bits not 32 bits"))
+        for (pos, char) in value.as_bytes().iter().enumerate() {
+            let bits: Option<Inner> = CHAR_TABLE.iter().enumerate().find_map(|(bits, c)| {
+                (char == c).then(|| bits.try_into().expect("bits not 64 bits"))
             });
 
             match bits {
                 None => return Err(Error::IllegalCharacters),
                 Some(bits) => {
-                    if pos < 5 {
+                    if pos < ID_LENGTH - 1 {
                         n = (n << 6) | bits;
                     } else {
-                        n = (n << 2) | bits;
+                        n = (n << 4) | bits;
                     }
                 }
             }
@@ -77,32 +109,61 @@ impl FromStr for Id {
     }
 }
 
-impl From<u32> for Id {
-    fn from(n: u32) -> Self {
+impl From<Inner> for Id {
+    fn from(n: Inner) -> Self {
         Self { n }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::i64;
+
     use super::*;
 
     #[test]
-    fn convert_u32_to_id_and_back() {
+    fn convert_inner_to_id_and_back() {
         let id = Id::from(0);
-        assert_eq!(id.to_string(), "aaaaaa");
-        assert_eq!(id.as_u32(), 0);
+        assert_eq!(id.to_string(), "aaaaaaaaaaa");
+        assert_eq!(id.as_inner(), 0);
+        assert_eq!(Id::from_str(&id.to_string()).unwrap(), id);
+
+        let id = Id::from(-1);
+        assert_eq!(id.to_string(), "++++++++++p");
+        assert_eq!(id.as_inner(), -1);
+        assert_eq!(Id::from_str(&id.to_string()).unwrap(), id);
 
         let id = Id::from(0xffffffff);
-        assert_eq!(id.to_string(), "+++++d");
-        assert_eq!(id.as_u32(), 0xffffffff);
+        assert_eq!(id.to_string(), "aaaaap++++p");
+        assert_eq!(id.as_inner(), 0xffffffff);
+        assert_eq!(Id::from_str(&id.to_string()).unwrap(), id);
+
+        let id = Id::from(i64::MAX);
+        assert_eq!(id.to_string(), "F+++++++++p");
+        assert_eq!(id.as_inner(), i64::MAX);
+        assert_eq!(Id::from_str(&id.to_string()).unwrap(), id);
+
+        let id = Id::from(i64::MIN);
+        assert_eq!(id.to_string(), "Gaaaaaaaaaa");
+        assert_eq!(id.as_inner(), i64::MIN);
+        assert_eq!(Id::from_str(&id.to_string()).unwrap(), id);
     }
 
     #[test]
     fn convert_id_from_string() {
-        assert!(Id::from_str("abDE+-").is_ok());
+        /* Support ID generated in the old 32-bit format */
+        //assert!(Id::from_str("abDE+-").is_ok());
         assert!(Id::from_str("#bDE+-").is_err());
         assert!(Id::from_str("abDE+-1").is_err());
         assert!(Id::from_str("abDE+").is_err());
+
+        /* New 64-bit format */
+        assert_eq!(
+            Id::from_str("abDE+-12345").unwrap(),
+            Id::from(6578377758007225)
+        );
+        assert!(Id::from_str("#bDE+-12345").is_err());
+        assert!(Id::from_str("abDE+-123456").is_err());
+        assert!(Id::from_str("abDE+12345").is_err());
     }
 }

--- a/src/routes/form.rs
+++ b/src/routes/form.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use crate::db::write;
 use crate::env::BASE_PATH;
-use crate::id::Id;
+use crate::id::{Id, Inner};
 use crate::{pages, AppState, Error};
 use axum::extract::{Form, State};
 use axum::response::Redirect;
@@ -50,7 +50,7 @@ pub async fn insert(
 ) -> Result<(SignedCookieJar, Redirect), pages::ErrorResponse<'static>> {
     let id: Id = tokio::task::spawn_blocking(|| {
         let mut rng = rand::thread_rng();
-        rng.gen::<u32>()
+        rng.gen::<Inner>()
     })
     .await
     .map_err(Error::from)?

--- a/src/routes/json.rs
+++ b/src/routes/json.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU32;
 use crate::db::write;
 use crate::env::BASE_PATH;
 use crate::errors::{Error, JsonErrorResponse};
-use crate::id::Id;
+use crate::id::{Id, Inner};
 use crate::AppState;
 use axum::extract::State;
 use axum::Json;
@@ -45,7 +45,7 @@ pub async fn insert(
 ) -> Result<Json<RedirectResponse>, JsonErrorResponse> {
     let id: Id = tokio::task::spawn_blocking(|| {
         let mut rng = rand::thread_rng();
-        rng.gen::<u32>()
+        rng.gen::<Inner>()
     })
     .await
     .map_err(Error::from)?

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -39,7 +39,7 @@ mod tests {
     async fn unknown_paste() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::new(make_app()?).await;
 
-        let res = client.get(&BASE_PATH.join("000000")).send().await?;
+        let res = client.get(&BASE_PATH.join("00000000000")).send().await?;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
         Ok(())


### PR DESCRIPTION
Expand the value space from 2^32 to 2^64, resulting in keys of length 11 instead of 6.
In particular important for one-time-pastes.
i64 is used as inner type since sqlite does not support storing u64.