### PR TITLE
Security headers

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -15,7 +15,8 @@ pub struct Metadata<'a> {
 
 pub const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub const CSS_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 30 * 6);
+pub const CSS_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 30 * 6); // 6 month
+pub const JS_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 30 * 6); // 6 month
 
 pub const FAVICON_MAX_AGE: Duration = Duration::from_secs(86400);
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -30,6 +30,8 @@ pub static DATA: LazyLock<Data> = LazyLock::new(|| {
     let style = Css::new("style", include_str!("themes/style.css"));
     let light = Css::new("light", &LIGHT_CSS);
     let dark = Css::new("dark", &DARK_CSS);
+    let index = Js::new(include_str!("javascript/index.js"));
+    let paste = Js::new(include_str!("javascript/paste.js"));
     let syntax_set: SyntaxSet =
         syntect::dumps::from_binary(include_bytes!("../assets/newlines.packdump"));
     let mut syntaxes = syntax_set.syntaxes().to_vec();
@@ -39,6 +41,8 @@ pub static DATA: LazyLock<Data> = LazyLock::new(|| {
         style,
         light,
         dark,
+        index,
+        paste,
         syntax_set,
         syntaxes,
     }
@@ -50,10 +54,17 @@ pub struct Css<'a> {
     pub content: &'a str,
 }
 
+/// Javascript content.
+pub struct Js<'a> {
+    pub content: &'a str,
+}
+
 pub struct Data<'a> {
     pub style: Css<'a>,
     pub light: Css<'a>,
     pub dark: Css<'a>,
+    pub index: Js<'a>,
+    pub paste: Js<'a>,
     pub syntax_set: SyntaxSet,
     pub syntaxes: Vec<SyntaxReference>,
 }
@@ -68,6 +79,12 @@ impl<'a> Css<'a> {
         );
 
         Self { name, content }
+    }
+}
+
+impl<'a> Js<'a> {
+    fn new(content: &'a str) -> Self {
+        Self { content }
     }
 }
 

--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -1,0 +1,69 @@
+const textarea = document.getElementById('text');
+
+function dropHandler(ev) {
+  ev.preventDefault();
+
+  if (ev.dataTransfer.items) {
+    const item = ev.dataTransfer.items[0];
+
+    if (item.kind === 'file') {
+      item.getAsFile().text().then((value) => textarea.value = value);
+    }
+  } else {
+    const item = ev.dataTransfer.files[0];
+    item.text().then((value) => textarea.value = value);
+  }
+}
+
+textarea.addEventListener('drop', dropHandler);
+
+function dragOverHandler(ev) {
+  ev.preventDefault();
+}
+
+textarea.addEventListener('dragover', dragOverHandler);
+
+function keyDownHandler(ev) {
+  if (ev.ctrlKey && ev.key == 's') {
+    ev.preventDefault();
+
+    textarea.form.submit();
+  }
+}
+
+textarea.addEventListener('keydown', keyDownHandler);
+
+function openFile() {
+  let input = document.createElement("input");
+  input.type = "file";
+  input.onchange = ev => {
+    const item = ev.target.files[0];
+
+    item.text().then((value) => textarea.value = value);
+  };
+
+  input.click();
+}
+
+const openbutton = document.getElementById('open');
+openbutton.addEventListener('click', openFile);
+
+const filter = document.getElementById("filter");
+
+function filterLangs(ev) {
+  ev.preventDefault();
+  let langs = document.getElementById("langs");
+  const term = filter.value.toLowerCase();
+
+  for (option of langs) {
+    if (option.innerText.toLowerCase().includes(term)) {
+      option.style.display = "";
+    }
+    else {
+      option.style.display = "none";
+    }
+  }
+}
+
+filter.addEventListener('change', filterLangs);
+filter.addEventListener('keyup', filterLangs);

--- a/src/javascript/paste.js
+++ b/src/javascript/paste.js
@@ -1,0 +1,44 @@
+const BASE_PATH = document.getElementById('js_base_path').innerHTML;
+const BASE_PATH_ID = document.getElementById('js_base_path_id').innerHTML;
+const EXT = document.getElementById('js_ext').innerHTML;
+
+document.addEventListener('keydown', onKey);
+
+function onKey(e) {
+  if (e.key == 'n') {
+    window.location.href = BASE_PATH;
+  }
+  else if (e.key == 'r') {
+    window.location.href = `${BASE_PATH_ID}?fmt=raw`;
+  }
+  else if (e.key == 'y') {
+    navigator.clipboard.writeText(window.location.href);
+  }
+  else if (e.key == 'd') {
+    window.location.href = `${BASE_PATH_ID}?dl=${EXT}`;
+  }
+  else if (e.key == 'q') {
+    window.location.href = `${BASE_PATH_ID}?fmt=qr`;
+  }
+  else if (e.key == 'p') {
+    window.location.href = `${BASE_PATH_ID}`;
+  }
+  else if (e.key == '?') {
+    var overlay = document.getElementById("overlay");
+
+    overlay.style.display = overlay.style.display != "block" ? "block" : "none";
+    overlay.onclick = function() {
+      if (overlay.style.display == "block") {
+        overlay.style.display = "none";
+      }
+    };
+  }
+
+  if (e.keyCode == 27) {
+    var overlay = document.getElementById("overlay");
+
+    if (overlay.style.display == "block") {
+      overlay.style.display = "none";
+    }
+  }
+}

--- a/src/routes/assets.rs
+++ b/src/routes/assets.rs
@@ -32,6 +32,21 @@ fn favicon() -> impl IntoResponse {
     )
 }
 
+fn js_headers() -> impl IntoResponseParts {
+    (
+        TypedHeader(headers::ContentType::from(mime::TEXT_JAVASCRIPT)),
+        TypedHeader(headers::CacheControl::new().with_max_age(env::JS_MAX_AGE)),
+    )
+}
+
+fn index_js() -> impl IntoResponse {
+    (js_headers(), DATA.index.content)
+}
+
+fn paste_js() -> impl IntoResponse {
+    (js_headers(), DATA.paste.content)
+}
+
 pub fn routes() -> Router<AppState> {
     let style_name = &DATA.style.name;
     Router::new()
@@ -39,4 +54,6 @@ pub fn routes() -> Router<AppState> {
         .route(&format!("/{style_name}"), get(|| async { style_css() }))
         .route("/dark.css", get(|| async { dark_css() }))
         .route("/light.css", get(|| async { light_css() }))
+        .route("/index.js", get(|| async { index_js() }))
+        .route("/paste.js", get(|| async { paste_js() }))
 }

--- a/src/themes/style.css
+++ b/src/themes/style.css
@@ -104,6 +104,10 @@ header .navigation:hover {
   cursor: pointer;
 }
 
+#form {
+  height: 100%;
+}
+
 button {
   font-family: "JetBrains Mono", monospace;
   font-size: 1.125rem;
@@ -266,4 +270,17 @@ td.line-number {
 
 .text-center {
   text-align: center;
+}
+
+#encrypted-grid1 {
+  grid-row: 1/2;
+}
+
+#encrypted-grid1 input {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+#encrypted-grid2 {
+  grid-row: 2/3;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     {% block head %}{% endblock %}
   </head>
   <body>
+    {% block body_top %}{% endblock %}
     <div id="main-container">
       <header>
         <span id="nav-title"><a href="{{ base_path.path() }}" class="navigation">home</a></span>

--- a/templates/encrypted.html
+++ b/templates/encrypted.html
@@ -8,11 +8,11 @@
     <form action="/{{ id }}.{{ ext }}{{ query }}" method="post">
 {% endif %}
 <div class="decrypt-container">
-      <div style="grid-row: 1/2;">
-        <label for "password">Password</label>
-        <input type="password" name="password" autofocus/>
+      <div id="encrypted-grid1">
+        <label for="password">Password</label>
+        <input type="password" id="password" name="password" autofocus>
       </div>
-      <div style="grid-row: 2/3;">
+      <div id="encrypted-grid2">
         <button class="button">Decrypt</button>
       </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,76 +1,18 @@
 {% extends "base.html" %}
 
 {% block head %}
-<script>
-  function dropHandler(ev) {
-    ev.preventDefault();
-
-    let textarea = document.getElementById('text');
-
-    if (ev.dataTransfer.items) {
-      const item = ev.dataTransfer.items[0];
-
-      if (item.kind === 'file') {
-        item.getAsFile().text().then((value) => textarea.value = value);
-      }
-    } else {
-      const item = ev.dataTransfer.files[0];
-      item.text().then((value) => textarea.value = value);
-    }
-  }
-
-  function dragOverHandler(ev) {
-    ev.preventDefault();
-  }
-
-  function keyDownHandler(ev) {
-    if (ev.ctrlKey && ev.key == 's') {
-      ev.preventDefault();
-
-      let textarea = document.getElementById('text');
-      textarea.form.submit();
-    }
-  }
-
-  function openFile() {
-    let input = document.createElement("input");
-    input.type = "file";
-    input.onchange = ev => {
-      const item = ev.target.files[0];
-
-      let textarea = document.getElementById('text');
-      item.text().then((value) => textarea.value = value);
-    };
-
-    input.click();
-  }
-
-  function filterLangs(ev) {
-    ev.preventDefault();
-    let langs = document.getElementById("langs");
-    const term = document.getElementById("filter").value.toLowerCase();
-
-    for (option of langs) {
-      if (option.innerText.toLowerCase().includes(term)) {
-        option.style.display = "";
-      }
-      else {
-        option.style.display = "none";
-      }
-    }
-  }
-</script>
+<script defer src="{{ base_path.join("index.js") }}"></script>
 {% endblock %}
 
 {% block nav %}
-    <li><button onclick="openFile()" class="navigation">open</button></li>
+    <li><button id="open" class="navigation">open</button></li>
 {% endblock %}
 
 {%- block content -%}
-    <form action="{{ base_path.path() }}" method="post" style="height: 100%;">
+    <form id="form" action="{{ base_path.path() }}" method="post">
       <div class="container">
         <div class="content">
-          <textarea id="text" name="text" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" onkeydown="keyDownHandler(event);" autofocus></textarea>
+          <textarea id="text" name="text" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" autofocus></textarea>
         </div>
         <div class="controls">
           <div class="extensions-list">
@@ -83,7 +25,7 @@
             </select>
           </div>
           <div class="extension-filter">
-            <input type="search" id="filter" placeholder="Filter ..." onchange="filterLangs(event);" onkeyup="filterLangs(event)">
+            <input type="search" id="filter" placeholder="Filter ...">
           </div>
           <div class="expiration-list">
             <select name="expires" size="8">

--- a/templates/paste.html
+++ b/templates/paste.html
@@ -1,48 +1,13 @@
 {% extends "base.html" %}
 
 {% block head %}
-<script>
-  document.addEventListener('keydown', onKey);
+<script defer src="{{ base_path.join("paste.js") }}"></script>
+{% endblock %}
 
-  function onKey(e) {
-    if (e.key == 'n') {
-      window.location.href = '{{ base_path.path() }}';
-    }
-    else if (e.key == 'r') {
-      window.location.href = '{{ base_path.join(id) }}?fmt=raw';
-    }
-    else if (e.key == 'y') {
-      navigator.clipboard.writeText(window.location.href);
-    }
-    else if (e.key == 'd') {
-      window.location.href = '{{ base_path.join(id) }}?dl={{ ext }}';
-    }
-    else if (e.key == 'q') {
-      window.location.href = '{{ base_path.join(id) }}?fmt=qr';
-    }
-    else if (e.key == 'p') {
-      window.location.href = '{{ base_path.join(id) }}';
-    }
-    else if (e.key == '?') {
-      var overlay = document.getElementById("overlay");
-
-      overlay.style.display = overlay.style.display != "block" ? "block" : "none";
-      overlay.onclick = function() {
-        if (overlay.style.display == "block") {
-          overlay.style.display = "none";
-        }
-      };
-    }
-
-    if (e.keyCode == 27) {
-      var overlay = document.getElementById("overlay");
-
-      if (overlay.style.display == "block") {
-        overlay.style.display = "none";
-      }
-    }
-  }
-</script>
+{% block body_top %}
+<span id="js_base_path" hidden>{{ base_path.path() }}</span>
+<span id="js_base_path_id" hidden>{{ base_path.join(id) }}</span>
+<span id="js_ext" hidden>{{ ext }}</span>
 {% endblock %}
 
 {% block nav %}


### PR DESCRIPTION
Modern browser support security headers, in particular Content Security
Policy (CSP)(https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
These can help mitigating XSS vulnerabilities, in the case of pastes by
disallowing inline styles and scripts.

Move all current inline styles into the global style.css, and refactor
all inline javascript into separate asset files.