### PR TITLE
Update Dockerfile to use Rust 1.83

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # --- build image
 
-FROM rust:1.80 AS builder
+FROM rust:1.83 AS builder
 
 RUN rustup target add x86_64-unknown-linux-musl
 RUN apt update && apt install -y musl-tools musl-dev


### PR DESCRIPTION
Bump Rust version due to

```
4.718 error: rustc 1.80.1 is not supported by the following package:                                                                                                                         
4.718   wastebin@2.5.0 requires rustc 1.83     
```