### PR TITLE
Lock 0.x dependencies to semver-compatible versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,36 +9,36 @@ askama = { version = "0.12", default-features = false, features = ["with-axum"] 
 askama_axum = { version = "0.4" }
 async-compression = { version = "0.4", features = ["tokio", "zstd"] }
 axum = { version = "0.7", features = ["json", "query"] }
-axum-extra = { version = "0", features = ["cookie-signed", "typed-header"] }
+axum-extra = { version = "0.9", features = ["cookie-signed", "typed-header"] }
 bytes = "1"
 chacha20poly1305 = "0.10.1"
-hex = "0"
-lru = "0"
-mime = "0"
+hex = "0.4"
+lru = "0.12"
+mime = "0.3"
 qrcodegen = "1"
-rand = "0"
+rand = "0.8"
 rusqlite = { version = "0.32", features = ["bundled"] }
 rusqlite_migration = { version = "1", default-features = false }
 rust-argon2 = "2.0.0"
-sha2 = "0"
+sha2 = "0.10"
 serde = { version = "1", features = ["derive"] }
 syntect = { version = "5", default-features = false, features = ["html", "plist-load", "regex-fancy"] }
 thiserror = "2"
 time = { version = "0.3", features = ["macros", "serde"] }
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5", default-features = false }
-tower-http = { version = "0", features = ["compression-full", "limit", "timeout", "trace"] }
-tracing = "0"
-tracing-subscriber = "0"
+tower-http = { version = "0.6", features = ["compression-full", "limit", "timeout", "trace"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 url = "2"
 zstd = "0.13"
 parking_lot = "0.12.1"
 http = "1.1.0"
 
 [dev-dependencies]
-reqwest = { version = "0", default-features = false, features = ["cookies", "json"] }
-tower = { version = "0", default-features = false, features = ["util", "make"] }
-tower-service = "0"
+reqwest = { version = "0.12", default-features = false, features = ["cookies", "json"] }
+tower = { version = "0.5", default-features = false, features = ["util", "make"] }
+tower-service = "0.3"
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
Specifying dependencies as `= "0"` is almost exactly like "specifying" `= "*"` for crates >= 1.x. I realize there is a lockfile, but it still seems reckless.