### PR TITLE
Bump `Dockerfile.arm`'s rust to 1.83

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,5 +1,5 @@
 # --- build image
-FROM rust:1.80 AS builder
+FROM rust:1.83 AS builder
 
 RUN rustup target add aarch64-unknown-linux-musl && \
     apt-get update && \


### PR DESCRIPTION
Currently, the build fails on ARM with the error `wastebin@2.5.0 requires rustc 1.83` as the ARM dockerfile is not up-to-date with the main Dockerfile. This PR simply bumps the version to fix that, matching commit bf31627.