### PR TITLE
Enforce paste content size limit

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,10 @@ pub enum Error {
     Migration(#[from] rusqlite_migration::Error),
     #[error("wrong size")]
     WrongSize,
+    #[error("unsupported media type")]
+    UnsupportedMediaType,
+    #[error("request too big")]
+    BigRequest,
     #[error("illegal characters")]
     IllegalCharacters,
     #[error("integer conversion error: {0}")]
@@ -76,6 +80,8 @@ impl From<Error> for StatusCode {
             | Error::Argon2(_)
             | Error::ChaCha20Poly1305Encrypt
             | Error::Axum(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::BigRequest => StatusCode::PAYLOAD_TOO_LARGE,
+            Error::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             Error::Delete | Error::ChaCha20Poly1305Decrypt => StatusCode::FORBIDDEN,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ pub struct AppState {
     key: Key,
     base_url: Option<Url>,
     max_expiration: Option<NonZeroU32>,
+    max_body_size: usize,
 }
 
 impl FromRef<AppState> for Key {
@@ -135,6 +136,7 @@ async fn start() -> Result<(), Box<dyn std::error::Error>> {
         key,
         base_url,
         max_expiration,
+        max_body_size,
     };
 
     tracing::debug!("serving on {addr}");

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -64,6 +64,7 @@ pub(crate) fn make_app() -> Result<Router, Box<dyn std::error::Error>> {
         key,
         base_url,
         max_expiration: None,
+        max_body_size: 1048576,
     };
 
     Ok(crate::make_app(4096, Duration::new(30, 0)).with_state(state))


### PR DESCRIPTION
Since commit 7cd3924c ("Use ServiceBuilder to layer middleware") the request body size is no longer enforced via the WASTEBIN_MAX_BODY_SIZE environment variable.

Reintroduce that enforcement.

Also tweak error propagation in the insert() handler to show nice formatted error sites instead of blank pages.