### PR TITLE
Fix QR code button overflowing past the screen

### DIFF
--- a/src/themes/style.css
+++ b/src/themes/style.css
@@ -90,6 +90,10 @@ header .nav-group {
   min-width: 0;
 }
 
+header #nav-group-actions {
+  min-width: fit-content;
+}
+
 header .nav-item {
   display: flex;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
           </div>
           {% block title %}{% endblock %}
         </div>
-        <div class="nav-group">
+        <div class="nav-group" id="nav-group-actions">
           {% block nav_common %}{% endblock %}
           {% block nav_specific %}{% endblock %}
         </div>


### PR DESCRIPTION
If the title is one very long word the QR code button is moved past the screen width. Fix by making that button group properly sized.

See e.g. https://bin.bloerg.net/pOjqAb