### PR TITLE
Versioning is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ to.
 
 ### Run with docker-compose
 ```
-version: '3.3'
 services:
   wastebin:
     environment:


### PR DESCRIPTION
https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313

Meant to fix this yesterday too. But i forgot. 
So here is another PR to fix a small thing. It will still run with it, just with a warning. So no reason for it to be there amymore.