### PR TITLE
flake.nix: use Cargo.lock directly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
 
             src = ./.;
 
-            cargoHash = "sha256-GCIPJbw6JJnET4AHu0xIctYHfRZ4sHH5u8LvAEbh6GY=";
+            cargoLock.lockFile = ./Cargo.lock;
 
             nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
There are two ways to specify the dependencies of a Nix-packaged Rust application: cargoHash and cargoLock. The latter reads dependencies from Cargo.lock directly, the first needs to be updated on every change to Cargo.lock.