### PR TITLE
Optimize crypto in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ unicode_not_nfc = "deny"
 unwrap_used = "deny"
 used_underscore_binding = "deny"
 
+[profile.dev.package.rust-argon2]
+opt-level = 3
+
 [profile.release]
 strip = "debuginfo"
 lto = "fat"


### PR DESCRIPTION
Optimize the argon crate even in debug builds, such that encryption and decryption are not tremendously slow.