### PR TITLE
Fix building ctl crate

### DIFF
--- a/crates/wastebin_core/Cargo.toml
+++ b/crates/wastebin_core/Cargo.toml
@@ -15,7 +15,7 @@ rusqlite_migration = { version = "1", default-features = false }
 rust-argon2 = "2.0.0"
 serde = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util"] }
+tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 tracing = { workspace = true }
 zstd = "0.13"
 


### PR DESCRIPTION
Building only the ctl crate currently fails via:

    error[E0432]: unresolved import `tokio::task::spawn_blocking`
       --> crates/wastebin_core/src/crypto.rs:5:5
        |
    5   | use tokio::task::spawn_blocking;
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `spawn_blocking` in `task`
        |
    note: found an item that was configured out
        --> /home/christian/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.1/src/task/mod.rs:273:23
        |
    273 |     pub use blocking::spawn_blocking;
        |                       ^^^^^^^^^^^^^^
    note: the item is gated behind the `rt` feature
       --> /home/christian/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.1/src/task/mod.rs:269:1
        |
    269 | / cfg_rt! {
    270 | |     pub use crate::runtime::task::{JoinError, JoinHandle};
    271 | |
    272 | |     mod blocking;
    ...   |
    323 | | }
        | |_^
        = note: this error originates in the macro `cfg_rt` (in Nightly builds, run with -Z macro-backtrace for more info)