### PR TITLE
Drop unnecessary html element closing slash

### DIFF
--- a/crates/wastebin_server/templates/index.html
+++ b/crates/wastebin_server/templates/index.html
@@ -43,7 +43,7 @@
           </div>
           <div class="controls-group">
             <div class="controls-checkbox-group">
-              <input type="checkbox" name="burn-after-reading" id="burn-after-reading" />
+              <input type="checkbox" name="burn-after-reading" id="burn-after-reading">
               <label for="burn-after-reading">🔥 after reading</label>
             </div>
           </div>


### PR DESCRIPTION
See https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values