### PR TITLE
feat: use multipart instead of x-www-form-urlencoded

### DIFF
--- a/crates/wastebin_server/Cargo.toml
+++ b/crates/wastebin_server/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 askama = { version = "0.13.0" }
 askama_web = { version = "0.13.0", features = ["axum-0.8"] }
-axum = { version = "0.8", features = ["json", "query", "macros"] }
+axum = { version = "0.8", features = ["json", "query", "macros", "multipart"] }
 axum-extra = { version = "0.10", features = ["cookie-signed", "typed-header"] }
 cached = { version = "0.55.0", default-features = false }
 hex = "0.4"

--- a/crates/wastebin_server/templates/index.html
+++ b/crates/wastebin_server/templates/index.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {%- block content -%}
-    <form id="form" action="/new" method="post">
+    <form id="form" action="/new" method="post" enctype="multipart/form-data">
       <div class="container">
         <div class="content">
           <textarea id="text" name="text" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" autofocus></textarea>


### PR DESCRIPTION
The goal is to prevent sending CRLF when the input uses LF (#148)

What is there :
* Change form enctype
* Adapt insert/form.rs to receive multipart data (https://docs.rs/axum/latest/axum/extract/struct.Multipart.html)