### PR TITLE
docs(readme): fix outdated example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ function paste_from_clipboard() {
     local URL=$(\
         jq -n --arg t "$(xclip -selection clipboard -o)" '{text: $t}' | \
             curl -s -H 'Content-Type: application/json' --data-binary @- ${API_URL}/ | \
-            jq -r '. | "${API_URL}\(.path)"')
+            jq -r '. | "'${API_URL}'\(.path)"' )
 
     xdg-open $URL
 }
@@ -244,7 +244,7 @@ function paste_from_stdin() {
     local API_URL="https://wastebin.tld"
     jq -Rns '{text: inputs}' | \
         curl  -s -H 'Content-Type: application/json' --data-binary @- ${API_URL}/ | \
-        jq -r '. | "${API_URL}\(.path)"')
+        jq -r '. | "'${API_URL}'\(.path)"'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,14 +223,17 @@ your `.bashrc` and you are good to go:
 
 ```bash
 function paste_from_clipboard() {
+    local API_URL="https://wastebin.tld"
     local URL=$(\
         jq -n --arg t "$(xclip -selection clipboard -o)" '{text: $t}' | \
-            curl -s -H 'Content-Type: application/json' --data-binary @- https://wastebin.tld/ | \
-            jq -r '. | "https://wastebin.tld\(.path)"')
+            curl -s -H 'Content-Type: application/json' --data-binary @- ${API_URL}/ | \
+            jq -r '. | "${API_URL}\(.path)"')
 
     xdg-open $URL
 }
 ```
+
+For wayland users, consider replace the `xclip ...` with `wl-paste` from `wl-clipboard`.
 
 ### Paste from stdin
 
@@ -238,9 +241,10 @@ To paste from stdin use the following function in your `.bashrc`:
 
 ```bash
 function paste_from_stdin() {
+    local API_URL="https://wastebin.tld"
     jq -Rns '{text: inputs}' | \
-        curl  -s -H 'Content-Type: application/json' --data-binary @- https://wastebin.tld/ | \
-        jq -r '. | "https://wastebin.tld\(.path)"'
+        curl  -s -H 'Content-Type: application/json' --data-binary @- ${API_URL}/ | \
+        jq -r '. | "${API_URL}\(.path)"')
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ your `.bashrc` and you are good to go:
 function paste_from_clipboard() {
     local URL=$(\
         jq -n --arg t "$(xclip -selection clipboard -o)" '{text: $t}' | \
-            curl -s -H 'Content-Type: application/json' --data-binary @- https://wastebin.tld/api | \
+            curl -s -H 'Content-Type: application/json' --data-binary @- https://wastebin.tld/ | \
             jq -r '. | "https://wastebin.tld\(.path)"')
 
     xdg-open $URL
@@ -239,8 +239,8 @@ To paste from stdin use the following function in your `.bashrc`:
 ```bash
 function paste_from_stdin() {
     jq -Rns '{text: inputs}' | \
-        curl  -s -H 'Content-Type: application/json' --data-binary @- https://wastebin.tld/api | \
-        jq -r '. | "wastebin.tld\(.path)"'
+        curl  -s -H 'Content-Type: application/json' --data-binary @- https://wastebin.tld/ | \
+        jq -r '. | "https://wastebin.tld\(.path)"'
 }
 ```
 


### PR DESCRIPTION
close #150 

We provide the POST api endpoint at `/` but the document is still suggesting POST to `/api`