### PR TITLE
ci: fix ci & support more platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,62 @@ on:
 
 jobs:
   release:
-    name: release ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    name: Release on ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-musl]
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            suffix: ""
+
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            suffix: ""
+
+          - target: riscv64gc-unknown-linux-gnu
+            os: ubuntu-latest
+            suffix: ""
+
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            suffix: ""
+
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            suffix: ""
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            suffix: .exe
+
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            suffix: .exe
+
     steps:
-      - uses: actions/checkout@master
-      - name: Compile and release
-        uses: rust-build/rust-build.action@v1.4.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v0
         with:
-          TOOLCHAIN_VERSION: 1.85.0
-          RUSTTARGET: ${{ matrix.target }}
-          EXTRA_FILES: "README.md LICENSE"
+          target: ${{ matrix.target }}
+          args: "--locked --release --bin wastebin --bin wastebin-ctl"
+          strip: true
+
+      - name: Prepare assets
+        shell: bash
+        run: |
+          mv target/${{ matrix.target }}/release/wastebin{,-ctl}${{ matrix.suffix }} .
+          tar -cvzf ${{ matrix.target }}.tar.gz LICENSE README.md wastebin{,-ctl}${{ matrix.suffix }}
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.target }}.tar.gz
+          # see https://stackoverflow.com/a/69919067
+          tag_name: ${{ github.event.release.tag_name }}
+          prerelease: false
+          make_latest: true


### PR DESCRIPTION
Fix current CI action, and introduce support for macos/linux/windows - arm64/x86_64 builds (and linux-riscv-glibc)