### PR TITLE
Update textarea properties

### DIFF
--- a/crates/wastebin_server/templates/index.html
+++ b/crates/wastebin_server/templates/index.html
@@ -18,7 +18,7 @@
     <form id="form" action="/new" method="post">
       <div class="container">
         <div class="content">
-          <textarea id="text" name="text" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" autofocus></textarea>
+          <textarea id="text" name="text" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="<paste text or drop file here>" autofocus required></textarea>
         </div>
         <div class="controls">
           <div class="controls-group">


### PR DESCRIPTION
Explicitly disable auto-capitalization, whose default depends on the browser.

Require input to avoid (accidental) empty pastes.