### PR TITLE
Allow ability to wrap lines on viewing pastes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # --- build image
 
-FROM rust:1.87 AS builder
+FROM rust:1.90 AS builder
 
 RUN rustup target add x86_64-unknown-linux-musl
 RUN apt update && apt install -y musl-tools musl-dev

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,6 +1,6 @@
 # --- build image
 
-FROM rust:1.87 AS builder
+FROM rust:1.90 AS builder
 
 RUN rustup target add aarch64-unknown-linux-musl && \
     apt-get update && \

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ When viewing a paste, you can use
 * <kbd>c</kbd> to copy the content to the clipboard,
 * <kbd>q</kbd> to display the current URL as a QR code,
 * <kbd>p</kbd> to view the formatted paste and
+* <kbd>w</kbd> to toggle line wrapping on and off (off by default)
 * <kbd>?</kbd> to view the list of keybindings.
 
 To paste some text you can also use the <kbd>ctrl</kbd>+<kbd>s</kbd> key

--- a/crates/wastebin_server/src/javascript/paste.js
+++ b/crates/wastebin_server/src/javascript/paste.js
@@ -55,6 +55,9 @@ function onKey(e) {
   else if (e.key == 'c') {
     copy();
   }
+  else if (e.key == 'w') {
+    document.body.classList.toggle('line-wrap');
+  }
   else if (e.key == '?') {
     var overlay = document.getElementById("overlay");
 

--- a/crates/wastebin_server/src/style.css
+++ b/crates/wastebin_server/src/style.css
@@ -285,6 +285,11 @@ td.line-number {
   user-select: text;
 }
 
+.line-wrap .line {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
 .flex-center {
   display: flex;
   align-items: center;


### PR DESCRIPTION
This attempts to resolve issue #177.

- Introduces a new line-wrap css class inheriting from the line class, which isn't used by default
- Introduces a keybinding that would allow user to toggle between wrapping lines and not while viewing a paste
- I had to update rust dependencies in the Dockerfile so as to allow testing with podman