### PR TITLE
Update Rust base image version to 1.95

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # --- build image
 
-FROM rust:1.90 AS builder
+FROM rust:1.95 AS builder
 
 RUN rustup target add \
     aarch64-unknown-linux-musl \


### PR DESCRIPTION
Bump it to align with the version declared in the TOML.

Otherwise:

```
4.193 error: rustc 1.90.0 is not supported by the following packages:
4.193   rusqlite_migration@2.6.0 requires rustc 1.95
4.193   rusqlite_migration@2.6.0 requires rustc 1.95
4.193   rusqlite_migration@2.6.0 requires rustc 1.95
4.193   rusqlite_migration@2.6.0 requires rustc 1.95
4.193   rusqlite_migration@2.6.0 requires rustc 1.95
4.193   wastebin@3.6.2 requires rustc 1.95
4.193   wastebin@3.6.2 requires rustc 1.95
4.193   wastebin-ctl@3.6.2 requires rustc 1.95
4.193   wastebin-ctl@3.6.2 requires rustc 1.95
4.193   wastebin_core@3.6.2 requires rustc 1.95
4.193   wastebin_core@3.6.2 requires rustc 1.95
4.193   wastebin_highlight@3.6.2 requires rustc 1.95
4.193   wastebin_highlight@3.6.2 requires rustc 1.95
```